### PR TITLE
Restrict Application Activity on dashboard to EPs that are  currently applying 

### DIFF
--- a/app/Modules/Group/Actions/ApplicationActivityGet.php
+++ b/app/Modules/Group/Actions/ApplicationActivityGet.php
@@ -21,6 +21,9 @@ class ApplicationActivityGet
                     ->whereHas('latestSubmission', function ($q) use ($user) {
                         $q->withStatus($this->getSubmissionStatusesForUser($user));
                     })
+                    ->whereHas('expertPanel', function ($q) {
+                        $q->applying();
+                    })
                     ->with([
                         'type',
                         'latestSubmission',

--- a/tests/Feature/End2End/ApplicationActivityTest.php
+++ b/tests/Feature/End2End/ApplicationActivityTest.php
@@ -7,6 +7,7 @@ use Laravel\Sanctum\Sanctum;
 use Illuminate\Testing\TestResponse;
 use App\Modules\Person\Models\Person;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
+use App\Modules\ExpertPanel\Actions\StepApprove;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Modules\Group\Actions\ApplicationSubmitStep;
 use Database\Seeders\NextActionAssigneesTableSeeder;
@@ -43,7 +44,7 @@ class ApplicationActivityTest extends TestCase
     /**
      * @test
      */
-    public function application_managers_see_submitted_applications()
+    public function application_managers_see_submitted_applications_not_completed()
     {
         $this->setupPermission(['ep-applications-manage']);
         $this->user->givePermissionTo('ep-applications-manage');
@@ -58,7 +59,7 @@ class ApplicationActivityTest extends TestCase
     /**
      * @test
      */
-    public function application_commenters_see_submitted_applications()
+    public function application_commenters_see_submitted_applications_that_are_not_completed()
     {
         $this->setupPermission(['ep-applications-comment']);
         $this->user->givePermissionTo('ep-applications-comment');
@@ -102,8 +103,16 @@ class ApplicationActivityTest extends TestCase
         $epAndSub4['submission']->update([
             'submission_status_id' => config('submissions.statuses.approved.id')
         ]);
+        $epAndSubApproved = $this->setupExpertPanelAndSubmission();
+        $epAndSubApproved['submission']->update([
+            'submission_status_id' => config('submissions.statuses.revisions-requested.id')
+        ]);
+        app()->make(StepApprove::class)->handle($epAndSubApproved['expertPanel'], \Carbon\Carbon::now());
+        app()->make(StepApprove::class)->handle($epAndSubApproved['expertPanel'], \Carbon\Carbon::now());
+        app()->make(StepApprove::class)->handle($epAndSubApproved['expertPanel'], \Carbon\Carbon::now());
+        app()->make(StepApprove::class)->handle($epAndSubApproved['expertPanel'], \Carbon\Carbon::now());
 
-        return [$epAndSub1, $epAndSub2, $epAndSub3, $epAndSub4];
+        return [$epAndSub1, $epAndSub2, $epAndSub3, $epAndSub4, $epAndSubApproved];
     }
 
 


### PR DESCRIPTION
This PR ensures only expert panels that do not have a `completed_date` will show up in the Application Activity list on the dashboard.