### PR TITLE
Record event_uuid for all activity_log entries and stream_messages

### DIFF
--- a/app/Actions/EventPublish.php
+++ b/app/Actions/EventPublish.php
@@ -28,7 +28,8 @@ class EventPublish
         if ($event->shouldPublish($event) && $message) {
             return $this->streamMessageCreate->handle(
                 topic: $event->getTopic(),
-                message: $message
+                message: $message,
+                eventUuid: $event->getEventUuid()
             );
         }
 

--- a/app/DataExchange/Actions/StreamMessageCreate.php
+++ b/app/DataExchange/Actions/StreamMessageCreate.php
@@ -11,7 +11,10 @@ class StreamMessageCreate
 
     public function handle(string $topic, $message, string $eventUuid): StreamMessage
     {
-        $event_uuid = $eventUuid;
-        return StreamMessage::create(compact('topic', 'message', 'event_uuid'));
+        return StreamMessage::create([
+            'topic' => $topic,
+            'message' => $message,
+            'event_uuid' => $eventUuid,
+        ]);
     }
 }

--- a/app/DataExchange/Actions/StreamMessageCreate.php
+++ b/app/DataExchange/Actions/StreamMessageCreate.php
@@ -9,8 +9,9 @@ class StreamMessageCreate
 {
     use AsJob;
 
-    public function handle(string $topic, $message): StreamMessage
+    public function handle(string $topic, $message, string $eventUuid): StreamMessage
     {
-        return StreamMessage::create(compact('topic', 'message'));
+        $event_uuid = $eventUuid;
+        return StreamMessage::create(compact('topic', 'message', 'event_uuid'));
     }
 }

--- a/app/DataExchange/Models/StreamMessage.php
+++ b/app/DataExchange/Models/StreamMessage.php
@@ -15,7 +15,8 @@ class StreamMessage extends Model
         'message',
         'topic',
         'sent_at',
-        'error'
+        'error',
+        'event_uuid'
     ];
     
     protected $dispatchesEvents = [

--- a/app/Events/AbstractEvent.php
+++ b/app/Events/AbstractEvent.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Events;
+
+use App\Events\Event;
+use Ramsey\Uuid\Uuid;
+
+class AbstractEvent implements Event
+{
+    private $eventUuid;
+
+    public function getEventUuid(): string
+    {
+        if (is_null($this->eventUuid)) {
+            $this->eventUuid = Uuid::uuid4()->toString();
+        }
+        return $this->eventUuid;
+    }
+}

--- a/app/Events/Event.php
+++ b/app/Events/Event.php
@@ -4,4 +4,5 @@ namespace App\Events;
 
 interface Event
 {
+    public function getEventUuid():string;
 }

--- a/app/Events/RecordableEvent.php
+++ b/app/Events/RecordableEvent.php
@@ -2,15 +2,17 @@
 
 namespace App\Events;
 
-use App\Events\Event;
+// use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Illuminate\Support\Str;
+use App\Events\AbstractEvent;
 use Illuminate\Support\Carbon;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
 
-abstract class RecordableEvent implements Event
+abstract class RecordableEvent extends AbstractEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/Listeners/RecordEvent.php
+++ b/app/Listeners/RecordEvent.php
@@ -7,10 +7,7 @@ use App\Events\RecordableEvent;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use App\Modules\Group\Events\JudgementEvent;
-use App\Modules\ExpertPanel\Events\ApplicationEvent;
 use App\Modules\ExpertPanel\Events\ExpertPanelEvent;
-use App\Modules\ExpertPanel\Events\ApplicationInitiated;
 
 class RecordEvent
 {

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -22,10 +22,10 @@ class Activity extends BaseActivity
          * and accessor
          */
         static::saving(function ($activity) {
-
-            if ($activity->properties && $activity->getExtraProperty('activity_type')) {
-                $activity->activity_type = $activity->getExtraProperty('activity_type');
+            if (!$activity->properties) {
+                return;
             }
+            $activity->activity_type = $activity->getExtraProperty('activity_type');
         });
     }
 
@@ -33,7 +33,7 @@ class Activity extends BaseActivity
     {
         parent::__construct($attributes);
 
-        $this->mergeFillable(['activity_type']);
+        $this->mergeFillable(['activity_type', 'event_uuid']);
     }
 
     public function getTypeAttribute()
@@ -53,6 +53,4 @@ class Activity extends BaseActivity
                 ? $this->properties['step']
                 : null;
     }
-    
-    
 }

--- a/app/Modules/Group/Events/JudgementEvent.php
+++ b/app/Modules/Group/Events/JudgementEvent.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Group\Events;
 
 use App\Events\Event;
+use App\Events\AbstractEvent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use App\Modules\Group\Models\Judgement;
@@ -12,7 +13,7 @@ use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
-class JudgementEvent implements Event
+class JudgementEvent extends AbstractEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/database/migrations/2024_02_22_172512_alter_activity_log_add_event_uuid.php
+++ b/database/migrations/2024_02_22_172512_alter_activity_log_add_event_uuid.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('activity_log', function ($table) {
+            $table->uuid('event_uuid')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('activity_log', function ($table) {
+            $table->dropColumn('event_uuid');
+        });
+    }
+};

--- a/database/migrations/2024_02_22_172548_alter_stream_messages_add_event_uuid.php
+++ b/database/migrations/2024_02_22_172548_alter_stream_messages_add_event_uuid.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stream_messages', function ($table) {
+            $table->uuid('event_uuid')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stream_messages', function ($table) {
+            $table->dropColumn('event_uuid');
+        });
+    }
+};

--- a/tests/Unit/Events/AbstractEventTest.php
+++ b/tests/Unit/Events/AbstractEventTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\AbstractEvent;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Validator\GenericValidator;
+
+final class AbstractEventTest extends TestCase
+{
+    private $event, $validator;
+
+    public function setup(): void
+    {
+        $this->event = $this->getMockBuilder(AbstractEvent::class)
+            ->getMockForAbstractClass();
+        $this->validator = new GenericValidator();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_an_event_uuid()
+    {
+        $this->assertIsString($this->event->getEventUuid());
+        $this->assertTrue($this->validator->validate($this->event->getEventUuid()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_same_uuid_every_time()
+    {
+        $this->assertEquals($this->event->getEventUuid(), $this->event->getEventUuid());
+    }
+}

--- a/tests/Unit/Listeners/RecordEventTest.php
+++ b/tests/Unit/Listeners/RecordEventTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Unit\Listeners;
+
+use Tests\TestCase;
+use App\Models\Activity;
+use App\Listeners\RecordEvent;
+use Illuminate\Support\Carbon;
+use App\Events\RecordableEvent;
+use App\Modules\User\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class RecordEventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $event, $listener;
+
+    public function setup(): void
+    {
+        parent::setup();
+        $this->event = $this->createDummyEvent();
+        $this->listener = new RecordEvent();
+    }
+
+    /**
+     * @test
+     */
+    public function it_records_event_uuid()
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertEquals('test_uuid', Activity::first()->event_uuid);
+    }
+
+    /**
+     * @test
+     */
+    public function when_no_authed_user_it_does_not_record_causer():void
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertNull(Activity::first()->causer_id);
+    }
+
+    /**
+     * @test
+     */
+    public function when_authed_user_it_records_causer():void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $this->listener->handle($this->event);
+
+        $this->assertEquals($user->id, Activity::first()->causer_id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_records_properties():void
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertEquals('test_value', Activity::first()->properties['test_property']);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_records_the_subject():void
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertEquals(User::class, Activity::first()->subject_type);
+        $this->assertEquals(999, Activity::first()->subject_id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_records_the_log_entry():void
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertEquals($this->event->getLogEntry(), Activity::first()->description);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_sets_the_event_log_date_as_created_at():void
+    {
+        $this->listener->handle($this->event);
+
+        $this->assertEquals($this->event->getLogDate(), Activity::first()->created_at);
+    }
+    
+
+    private function createDummyEvent()
+    {
+        return new class extends RecordableEvent {
+            public function getLogEntry(): string
+            {
+                return 'test_log_entry';
+            }
+
+            public function getLog(): string
+            {
+                return 'test_log';
+            }
+
+            public function hasSubject(): bool
+            {
+                return true;
+            }
+
+            public function getSubject(): Model
+            {
+                return User::factory()->create(['id' => 999]);
+            }
+
+            public function getProperties(): ?array
+            {
+                return ['test_property' => 'test_value'];
+            }
+
+            public function getLogDate(): Carbon
+            {
+                return Carbon::parse('2021-01-01 00:00:00');
+            }
+
+            public function getEventUuid(): string
+            {
+                return 'test_uuid';
+            }
+        };
+    }
+}

--- a/tests/Unit/Models/ActivityTest.php
+++ b/tests/Unit/Models/ActivityTest.php
@@ -10,7 +10,7 @@ class ActivityTest extends TestCase
     /**
      * @test
      */
-    public function has_fillable_activity_type_attribute()
+    public function has_fillable_activity_type_attribute(): void
     {
         $activity = new Activity();
         $activity->fill(['activity_type'=>'test_type']);
@@ -18,6 +18,16 @@ class ActivityTest extends TestCase
         $this->assertEquals('test_type', $activity->activity_type);
     }
 
+    /**
+     * @test
+     */
+    public function has_fillable_event_uuid_attribute(): void
+    {
+        $activity = new Activity();
+        $activity->fill(['event_uuid'=>'test_uuid']);
+
+        $this->assertEquals('test_uuid', $activity->event_uuid);
+    }
 
     /**
      * @test


### PR DESCRIPTION
This PR adds `event_uuid` columns to `activity_log` and `stream_messages` tables.  Each event returns (and memo-izes) a random UUID when requested that is then stored for both the recorded `Activity` in `activity_log` and `StreamMessage` in `stream_messages`.

To facilitate this all events now inherit from the new `AbstractEvent` class that implements the updated `Event` interface.  

Storing event_uuid is left to `App\Listeners\RecordEvent` and `App\Actions\PublishEvent` "listeners" respectively.

Note that this PR is compared to [dx-topic-replay](https://github.com/clingen-data-model/gpm/tree/dx-topic-replay), not main.  This was done for ease of review.