### PR TITLE
Cspec timestamp fixes

### DIFF
--- a/app/Console/Commands/Dev/FixupCSpecApprovalDates.php
+++ b/app/Console/Commands/Dev/FixupCSpecApprovalDates.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands\Dev;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use App\DataExchange\Models\IncomingStreamMessage;
+use App\Modules\ExpertPanel\Models\ExpertPanel;
+use App\Modules\ExpertPanel\Events\StepDateApprovedUpdated;
+
+class FixupCSpecApprovalDates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fixup:cspec-approval-dates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix historical data of timestamps for cspec steps 2 and 3 approval dates (GPM-371 and GPM-376).';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    private function updateStepForAllApplications($step, $eventName)
+    {
+        $updatedRecordCount = 0;
+
+        $mostRecentApprovals = IncomingStreamMessage::select(
+            DB::raw("payload->>'$.cspecDoc.affiliationId' as affiliationId"),
+            DB::raw("MAX(payload->>'$.cspecDoc.status.modifiedAt') as latestApproved")
+        )
+            ->where('payload->cspecDoc->status->event', $eventName)
+            ->groupBy('affiliationId')
+            ->get()
+            ->keyBy('affiliationId');
+
+        foreach ($mostRecentApprovals as $affiliationId => $item) {
+            $expertPanel = ExpertPanel::findByAffiliationId($affiliationId);
+            if ($expertPanel == null) {
+                Log::warning('Received message for unknown expert panel: ' . $affiliationId);
+                continue;
+            }
+            $dateApproved = new Carbon($item->latestApproved);
+            $oldApprovalDate = new Carbon($expertPanel->{'step_' . $step . '_approval_date'});
+            if ($oldApprovalDate->diffInDays($dateApproved, true) <= 1) {
+                //Log::info('Approval date for step ' . $step . ' for ' . $expertPanel->displayName . ' is already within 3 days of the new date. Skipping.');
+                continue;
+            }
+
+            $expertPanel->{'step_' . $step . '_approval_date'} = $dateApproved;
+
+            DB::beginTransaction();
+            try {
+                $expertPanel->save();
+                Event::dispatch(
+                    new StepDateApprovedUpdated(
+                        application: $expertPanel,
+                        step: $step,
+                        dateApproved: $dateApproved
+                    )
+                );
+                DB::commit();
+                $updatedRecordCount++;
+            } catch (\Exception $e) {
+                DB::rollBack();
+                Log::error('Failed to update approval date for step ' . $step . ' for ' . $expertPanel->displayName . ': ' . $e->getMessage());
+                continue;
+            }
+        }
+        Log::info('Updated ' . $updatedRecordCount . ' records for step ' . $step . ' with event ' . $eventName . '.');
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->updateStepForAllApplications(2, 'classified-rules-approved');
+        $this->updateStepForAllApplications(3, 'pilot-rules-approved');
+    }
+}

--- a/app/DataExchange/Actions/ClassifiedRulesApprovedProcessor.php
+++ b/app/DataExchange/Actions/ClassifiedRulesApprovedProcessor.php
@@ -8,16 +8,13 @@ use App\Modules\ExpertPanel\Models\ExpertPanel;
 use App\Modules\ExpertPanel\Actions\StepApprove;
 use App\DataExchange\Models\IncomingStreamMessage;
 use App\DataExchange\Exceptions\DataSynchronizationException;
-use App\Modules\ExpertPanel\Actions\SpecificationAndRulsetsSync;
-use App\Modules\ExpertPanel\Actions\SpecificationCreate;
-use App\Modules\ExpertPanel\Actions\SpecificationRulesetCreate;
-use App\Modules\ExpertPanel\Actions\SpecificationRulesetSync;
+use App\Modules\ExpertPanel\Actions\SpecificationAndRulesetsSync;
 
 class ClassifiedRulesApprovedProcessor
 {
     public function __construct(
         private StepApprove $approveStepAction,
-        private SpecificationAndRulsetsSync $syncSpecification
+        private SpecificationAndRulesetsSync $syncSpecification
     ) {
     }
 

--- a/app/DataExchange/Actions/ClassifiedRulesApprovedProcessor.php
+++ b/app/DataExchange/Actions/ClassifiedRulesApprovedProcessor.php
@@ -51,7 +51,7 @@ class ClassifiedRulesApprovedProcessor
 
         $this->approveStepAction->handle(
             expertPanel: $expertPanel,
-            dateApproved: Carbon::createFromTimestamp($message->timestamp),
+            dateApproved: new Carbon($cspecDoc->status->modifiedAt ?? $cspecDoc->eventTime ?? 0),
             notifyContacts: true
         );
     }

--- a/app/DataExchange/Actions/CspecDataSyncProcessor.php
+++ b/app/DataExchange/Actions/CspecDataSyncProcessor.php
@@ -5,19 +5,14 @@ namespace App\DataExchange\Actions;
 use Illuminate\Support\Facades\Log;
 use Lorisleiva\Actions\Concerns\AsJob;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
-use App\Modules\ExpertPanel\Models\RulesetStatus;
 use App\DataExchange\Models\IncomingStreamMessage;
-use App\Modules\ExpertPanel\Actions\SpecificationSync;
-use App\Modules\ExpertPanel\Models\SpecificationStatus;
-use App\Modules\ExpertPanel\Actions\SpecificationCreate;
-use App\Modules\ExpertPanel\Actions\SpecificationRulesetCreate;
-use App\Modules\ExpertPanel\Actions\SpecificationAndRulsetsSync;
+use App\Modules\ExpertPanel\Actions\SpecificationAndRulesetsSync;
 
 class CspecDataSyncProcessor
 {
     use AsJob;
 
-    public function __construct(private SpecificationAndRulsetsSync $syncSpecificationAndRulesets)
+    public function __construct(private SpecificationAndRulesetsSync $syncSpecificationAndRulesets)
     {
     }
 
@@ -28,7 +23,7 @@ class CspecDataSyncProcessor
 
         $expertPanel = ExpertPanel::findByAffiliationId($cspecDoc->affiliationId);
         if (!$expertPanel) {
-            Log::error('Received proposal-submitted event about EP with unkown affiliation id '.$cspecDoc->affiliationId);
+            Log::error('Received proposal-submitted event about EP with unknown affiliation id '.$cspecDoc->affiliationId);
             return;
         }
 

--- a/app/DataExchange/Actions/PilotRulesApprovedProcessor.php
+++ b/app/DataExchange/Actions/PilotRulesApprovedProcessor.php
@@ -9,16 +9,14 @@ use App\Modules\ExpertPanel\Models\ExpertPanel;
 use App\Modules\ExpertPanel\Actions\StepApprove;
 use App\DataExchange\Models\IncomingStreamMessage;
 use App\DataExchange\Exceptions\DataSynchronizationException;
-use App\Modules\ExpertPanel\Actions\SpecificationAndRulsetsSync;
-use App\Modules\ExpertPanel\Actions\SpecificationRulesetSync;
-use App\Modules\ExpertPanel\Actions\TaskCreateSustainedCurationReview;
+use App\Modules\ExpertPanel\Actions\SpecificationAndRulesetsSync;
 
 class PilotRulesApprovedProcessor
 {
     public function __construct(
         private StepApprove $approveStep,
         private TaskCreate $createTask,
-        private SpecificationAndRulsetsSync $syncSpecificationAndRulesets
+        private SpecificationAndRulesetsSync $syncSpecificationAndRulesets
     ) {
     }
 

--- a/app/DataExchange/Actions/PilotRulesApprovedProcessor.php
+++ b/app/DataExchange/Actions/PilotRulesApprovedProcessor.php
@@ -51,7 +51,7 @@ class PilotRulesApprovedProcessor
 
         $this->approveStep->handle(
             expertPanel: $expertPanel,
-            dateApproved: Carbon::createFromTimestamp($message->timestamp),
+            dateApproved: new Carbon($cspecDoc->status->modifiedAt ?? $cspecDoc->eventTime ?? 0),
             notifyContacts: true
         );
     }

--- a/app/DataExchange/Exceptions/UnsupportedIncomingMessage.php
+++ b/app/DataExchange/Exceptions/UnsupportedIncomingMessage.php
@@ -6,6 +6,6 @@ class UnsupportedIncomingMessage extends StreamingServiceException
 {
     public function __construct($message)
     {
-        parent::__construct('An unsupported event type with key '.$message->key.' was received on topic '.$message->topic.' with event '.$message->payload->cspecDoc->status->event, 401);
+        parent::__construct('An unsupported event type with key '.($message->key ?? 'undefined').' was received on topic '.$message->topic.' with payload '.json_encode($message->payload), 401);
     }
 }

--- a/app/DataExchange/Kafka/KafkaMessageStream.php
+++ b/app/DataExchange/Kafka/KafkaMessageStream.php
@@ -128,7 +128,7 @@ class KafkaMessageStream implements MessageStream
      */
     public function listTopics(): array
     {
-        $availableTopics = $this->kafkaConsumer->getMetadata(true, null, 60e3)->getTopics();
+        $availableTopics = $this->kafkaConsumer->getMetadata(true, null, 60000)->getTopics();
 
         return array_map(
             function ($topic) {

--- a/app/DataExchange/MessageHandlerFactory.php
+++ b/app/DataExchange/MessageHandlerFactory.php
@@ -39,7 +39,11 @@ class MessageHandlerFactory
     private function buildHandlerClassName($message)
     {
         $namespace = '\\App\\DataExchange\\Actions';
-        $event = $message->payload->cspecDoc->status->event;
+        try {
+            $event = $message->payload->cspecDoc->status->event;
+        } catch (\ErrorException $ex) {
+            throw new UnsupportedIncomingMessage($message);
+        }
         $className = Str::studly($event.'Processor');
 
         return $namespace.'\\'.$className;

--- a/app/Modules/ExpertPanel/Actions/SpecificationAndRulesetsSync.php
+++ b/app/Modules/ExpertPanel/Actions/SpecificationAndRulesetsSync.php
@@ -3,13 +3,11 @@
 namespace App\Modules\ExpertPanel\Actions;
 
 use App\Modules\ExpertPanel\Models\ExpertPanel;
-use App\Modules\ExpertPanel\Models\RulesetStatus;
 use App\Modules\ExpertPanel\Models\Specification;
-use App\Modules\ExpertPanel\Models\SpecificationStatus;
 use App\Modules\ExpertPanel\Actions\SpecificationRulesetSync;
 use App\Modules\ExpertPanel\Events\SpecificationStatusUpdated;
 
-class SpecificationAndRulsetsSync
+class SpecificationAndRulesetsSync
 {
     public function __construct(
         private SpecificationSync $syncSpecification,

--- a/app/Modules/ExpertPanel/Events/StepDateApprovedUpdated.php
+++ b/app/Modules/ExpertPanel/Events/StepDateApprovedUpdated.php
@@ -2,14 +2,10 @@
 
 namespace App\Modules\ExpertPanel\Events;
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class StepDateApprovedUpdated extends ExpertPanelEvent
 {
@@ -39,13 +35,4 @@ class StepDateApprovedUpdated extends ExpertPanelEvent
         ];
     }
 
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return \Illuminate\Broadcasting\Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
-    }
 }

--- a/app/Modules/ExpertPanel/Events/StepDateApprovedUpdated.php
+++ b/app/Modules/ExpertPanel/Events/StepDateApprovedUpdated.php
@@ -5,11 +5,16 @@ namespace App\Modules\ExpertPanel\Events;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
+use App\Modules\Group\Events\PublishableApplicationEvent;
+use App\Modules\Group\Events\Traits\IsPublishableApplicationEvent;
 use Illuminate\Broadcasting\InteractsWithSockets;
 
-class StepDateApprovedUpdated extends ExpertPanelEvent
+class StepDateApprovedUpdated extends ExpertPanelEvent implements PublishableApplicationEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
+    use IsPublishableApplicationEvent {
+        getPublishableMessage as protected getBaseMessage;
+    }
 
     /**
      * Create a new event instance.
@@ -33,6 +38,11 @@ class StepDateApprovedUpdated extends ExpertPanelEvent
             'new_date_approved' => $this->dateApproved,
             'old_approval_date' => $this->application->getOriginal('step_'.$this->step.'_approval_date')
         ];
+    }
+
+    public function getEventType(): string
+    {
+        return 'step_date_approved_updated';
     }
 
 }


### PR DESCRIPTION
Provides both fixes prospectively and generation of events to fix timestamps of old step 2 / step 3 approvals based on messages that come from the CSpec registry.

WIP until this can be discussed with other interested parties.