### PR TITLE
pendingCoi only for applying and active

### DIFF
--- a/app/Actions/ReportCOIDueMake.php
+++ b/app/Actions/ReportCOIDueMake.php
@@ -21,7 +21,7 @@ class ReportCOIDueMake extends ReportMakeAbstract
                     'first_name' => $p->first_name,
                     'last_name' => $p->last_name,
                     'email' => $p->email,
-                    'membership' => $p->membershipsWithPendingCoi->map(function ($m) { return $m->group->name; })
+                    'membership' => $p->membershipsWithPendingCoi->map(function ($m) { return $m->group->name; })->sort()->values()
                 ];
         })
         ->toArray();

--- a/app/Modules/Group/Models/Group.php
+++ b/app/Modules/Group/Models/Group.php
@@ -250,7 +250,7 @@ class Group extends Model implements HasNotes, HasMembers, RecordsEvents, HasDoc
 
     public function getHasCoiRequirementAttribute()
     {
-        return true;
+        return $this->group_status_id == config('groups.statuses.active.id') || $this->group_status_id == config('groups.statuses.applying.id');
     }
 
     // DOMAIN

--- a/tests/Unit/CoiApplyingActiveTest.php
+++ b/tests/Unit/CoiApplyingActiveTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Modules\Group\Models\Group;
+use App\Modules\Person\Models\Person;
+use App\Modules\Group\Models\GroupMember;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CoiApplyingActiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setup():void
+    {
+        parent::setup();
+        $this->setupForGroupTest();
+    }
+
+    /**
+     * @test
+     */
+    public function pending_coi_applies_to_applying_and_active_groups()
+    {
+        $groupMember = GroupMember::factory()->create();
+        $this->assertTrue($groupMember->person->inGroup($groupMember->group));
+
+        $group = $groupMember->group;
+        $person = $groupMember->person;
+
+        $group->group_status_id = config('groups.statuses.applying.id');
+        $group->save();
+        $this->assertEquals(1, $person->hasPendingCois()->count());
+
+        $group->save();
+        $group->group_status_id = config('groups.statuses.active.id');
+        $this->assertEquals(1, $person->hasPendingCois()->count());
+    }
+
+    /**
+     * @test
+     */
+    public function pending_coi_does_not_apply_to_inactive_groups()
+    {
+        $groupMember = GroupMember::factory()->create();
+        $this->assertTrue($groupMember->person->inGroup($groupMember->group));
+
+        $group = $groupMember->group;
+        $person = $groupMember->person;
+
+        $group->group_status_id = config('groups.statuses.inactive.id');
+        $group->save();
+        $this->assertEquals(0, $person->hasPendingCois()->count());
+    }
+}


### PR DESCRIPTION
Relevant to GPM-383. This is a restart of the GPM-383-retired-cdwg-is-still-asking-for-updates-to-coi branch to be a more-complete fix.

Instead of just filtering at time of making email notifications, this changes the behavior such that COIs are only considered "pending" for active or applying groups (not for inactive, retired, etc.)