### PR TITLE
fix guard for when trying to edit Person that does not have associated user

### DIFF
--- a/app/Modules/Person/Http/Resources/PersonDetailResource.php
+++ b/app/Modules/Person/Http/Resources/PersonDetailResource.php
@@ -18,7 +18,7 @@ class PersonDetailResource extends JsonResource
     {
         $data = parent::toArray($request);
         $user = $request->user();
-        if ($user->id === $this->user->id || $user->hasAnyRole(['admin', 'super-admin'])) {
+        if ($user->id === $this?->user?->id || $user->hasAnyRole(['admin', 'super-admin'])) {
             foreach (Person::$contact_details_private_fields as $field) {
                 $data[$field] = $this->$field;
             }


### PR DESCRIPTION
Intent (I think) of the guard is to allow viewing of this detail only if it's the viewing user's detail or if the viewing user is an admin.

However, for Person objects that don't have an associated User, this would result in an error from attempt to dereference through a null-valued object.