### PR TITLE
CGSP-592: add individual emails for cdwg oversight for step 1 approval

### DIFF
--- a/app/Mail/UserDefinedMailTemplates/InitialApprovalMailTemplate.php
+++ b/app/Mail/UserDefinedMailTemplates/InitialApprovalMailTemplate.php
@@ -33,5 +33,14 @@ class InitialApprovalMailTemplate extends AbstractUserDefinedMailTemplate
         ];
     }
 
+    public function getBCC(): array
+    {
+        return [
+            ['address' => 'hrehm@mgh.harvard.edu', 'name' => 'Heidi Rehm'],
+            ['address' => 'jonathan_berg@med.unc.edu', 'name' => 'Jonathon Berg'],
+            ['address' => 'splon@bcm.edu', 'name' => 'Sharon Plon'],
+        ];
+    }
+
 
 }


### PR DESCRIPTION
This is relevant to https://broadinstitute.atlassian.net/browse/CGSP-592 

Replacing #92 so the naming of the involved branch follows convention better.

Will need to check with invested users to ensure that we are sending emails for all relevant events (I'm not sure that initial commit by tmbattey-2021 would do so).