### PR TITLE
Add SCVCEP Group Type 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ consumed_messages/*
 
 .docker/mysql/db-init/*.sql.gz
 
+.DS_Store
+
 # built css & js
 # /public/css/*
 # /public/js/*

--- a/app/Modules/ExpertPanel/Actions/SpecificationsGet.php
+++ b/app/Modules/ExpertPanel/Actions/SpecificationsGet.php
@@ -17,7 +17,7 @@ class SpecificationsGet
 
     public function asController(Group $group)
     {
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             return response(['message' => 'Only VCEPs have specifications.'], 404);
         }
 

--- a/app/Modules/ExpertPanel/Models/ExpertPanel.php
+++ b/app/Modules/ExpertPanel/Models/ExpertPanel.php
@@ -226,14 +226,6 @@ class ExpertPanel extends Model implements HasNotes, HasMembers, BelongsToGroup,
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function groupType(): BelongsTo
-    {
-        return $this->belongsTo(GroupType::class);
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
     public function cdwg(): BelongsTo
     {
         return $this->belongsTo(Group::class, 'cdwg_id');
@@ -324,14 +316,28 @@ class ExpertPanel extends Model implements HasNotes, HasMembers, BelongsToGroup,
         return $query->whereNotNull('step_4_approval_date');
     }
 
+    public function scopeGroupType($query, $type)
+    {
+        $typeId = is_object($type) ? $type->id : $type;
+        
+        return $query->whereHas('group', function ($query) use ($typeId) {
+            $query->where('group_type_id', $typeId);
+        });
+    }
+    
     public function scopeTypeGcep($query)
     {
-        return $query->where('expert_panel_type_id', config('expert_panels.types.gcep.id'));
+        return $query->groupType(config('groups.types.gcep.id'));
     }
 
     public function scopeTypeVcep($query)
     {
-        return $query->where('expert_panel_type_id', config('expert_panels.types.vcep.id'));
+        return $query->groupType(config('groups.types.vcep.id'));
+    }
+
+    public function scopeTypeScvcep($query)
+    {
+        return $query->groupType(config('groups.types.scvcep.id'));
     }
 
 
@@ -382,16 +388,29 @@ class ExpertPanel extends Model implements HasNotes, HasMembers, BelongsToGroup,
             ->first();
     }
 
+    /**
+     * @deprecated Use group's isVcep accessor
+     */
     public function getIsVcepAttribute(): bool
     {
-        return $this->expert_panel_type_id == 2;
+        return $this->group->group_type_id == config('groups.types.vcep.id');
     }
 
+    /**
+     * @deprecated Use group's isGcep accessor
+     */
     public function getIsGcepAttribute(): bool
     {
-        return $this->expert_panel_type_id == 1;
+        return $this->group->group_type_id == config('groups.types.gcep.id');
     }
 
+    /**
+     * @deprecated Use group's isScvcep accessor
+     */
+    public function getIsScvcepAttribute(): bool
+    {
+        return $this->group->group_type_id == config('groups.types.scvcep.id');
+    }
 
     public function getNameAttribute()
     {

--- a/app/Modules/Group/Actions/ApplicationSaveChanges.php
+++ b/app/Modules/Group/Actions/ApplicationSaveChanges.php
@@ -40,7 +40,7 @@ class ApplicationSaveChanges
                                     : null;
         $group = $this->nhgriAttestation->handle($group, $nhgriAttestationDate);
 
-        if ($group->isVcep) {
+        if ($group->isVcepOrScvcep) {
             $group = $this->memberDescription->handle($group, $data->get('membership_description'));
             $group = $this->reanalysisAttestation
                         ->handle(

--- a/app/Modules/Group/Actions/EvidenceSummaryAdd.php
+++ b/app/Modules/Group/Actions/EvidenceSummaryAdd.php
@@ -19,7 +19,7 @@ class EvidenceSummaryAdd
 
     public function handle(Group $group, array $data): EvidenceSummary
     {
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             throw ValidationException::withMessages(['group' => ['You can not add an evidence summary to this group. Only VCEPs have evidence summaries.']]);
         }
 

--- a/app/Modules/Group/Actions/EvidenceSummaryDelete.php
+++ b/app/Modules/Group/Actions/EvidenceSummaryDelete.php
@@ -26,7 +26,7 @@ class EvidenceSummaryDelete
     public function asController(ActionRequest $request, $groupUuid, $summaryId)
     {
         $group = Group::findByUuidOrFail($groupUuid);
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             return;
         }
         $evidenceSummary = $group->expertPanel->evidenceSummaries()->findOrFail($summaryId);

--- a/app/Modules/Group/Actions/EvidenceSummaryUpdate.php
+++ b/app/Modules/Group/Actions/EvidenceSummaryUpdate.php
@@ -30,7 +30,7 @@ class EvidenceSummaryUpdate
     public function asController(ActionRequest $request, $groupUuid, $summaryId)
     {
         $group = Group::findByUuidOrFail($groupUuid);
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             throw ValidationException::withMessages(['group' => ['You can not add an evidence summary to this group. Only VCEPs have evidence summaries.']]);
         }
         $evidenceSummary = $group->expertPanel->evidenceSummaries()->findOrFail($summaryId);

--- a/app/Modules/Group/Actions/GeneUpdate.php
+++ b/app/Modules/Group/Actions/GeneUpdate.php
@@ -66,7 +66,7 @@ class GeneUpdate
         ];
 
         $group = $request->group;
-        if ($group->isVcep) {
+        if ($group->isVcepOrScvcep) {
             $rules['mondo_id'] = 'required|regex:/MONDO:\d\d\d\d\d\d\d/i|exists:'.$connectionName.'.diseases,mondo_id';
         }
 

--- a/app/Modules/Group/Actions/GenesAdd.php
+++ b/app/Modules/Group/Actions/GenesAdd.php
@@ -26,7 +26,7 @@ class GenesAdd
             throw ValidationException::withMessages(['group' => 'Genes can only be added to an Expert Panel.']);
         }
 
-        if ($group->isVcep) {
+        if ($group->isVcepOrScvcep) {
             return $this->addGenesToVcep->handle($group, $genes);
         }
         if ($group->isGcep) {
@@ -50,7 +50,7 @@ class GenesAdd
     {
         $gtConn = config('database.gt_db_connection');
         $group = $request->group;
-        if ($group->isVcep) {
+        if ($group->isVcepOrScvcep) {
             return [
                 'genes' => 'required|array|min:1',
                 'genes.*' => 'required|array:hgnc_id,mondo_id',

--- a/app/Modules/Group/Actions/GenesAddToVcep.php
+++ b/app/Modules/Group/Actions/GenesAddToVcep.php
@@ -26,7 +26,7 @@ class GenesAddToVcep
 
     public function handle(Group $group, array $genes): Group
     {
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             throw ValidationException::withMessages(['group' => 'The group is not a VCEP.']);
         }
 

--- a/app/Modules/Group/Actions/MembershipDescriptionUpdate.php
+++ b/app/Modules/Group/Actions/MembershipDescriptionUpdate.php
@@ -16,7 +16,7 @@ class MembershipDescriptionUpdate
 
     public function handle(Group $group, ?string $description): Group
     {
-        if (!$group->isVcep) {
+        if (!$group->isVcepOrScvcep) {
             throw ValidationException::withMessages(['membership_description' => ['A membership description can only be set for VCEPs.']]);
         }
 

--- a/app/Modules/Group/Models/Group.php
+++ b/app/Modules/Group/Models/Group.php
@@ -237,6 +237,17 @@ class Group extends Model implements HasNotes, HasMembers, RecordsEvents, HasDoc
         return $this->group_type_id == config('groups.types.gcep.id');
     }
 
+    public function getIsScvcepAttribute(): bool
+    {
+        return $this->group_type_id == config('groups.types.scvcep.id');
+    }
+
+    public function getIsVcepOrScvcepAttribute(): bool
+    {
+        return $this->isVcep || $this->isScvcep;
+    }
+
+
     public function getFullTypeAttribute()
     {
         return $this->type;

--- a/app/Modules/Group/Models/GroupType.php
+++ b/app/Modules/Group/Models/GroupType.php
@@ -24,6 +24,7 @@ class GroupType extends Model
     protected $fillable = [
         'name',
         'fullname',
+        'display_name',
         'can_be_parent'
     ];
 

--- a/app/Modules/Group/groups.php
+++ b/app/Modules/Group/groups.php
@@ -6,6 +6,7 @@ return [
             'id' => 1,
             'name' => 'wg',
             'fullname' => 'Working Group',
+            'display_name' => 'Working Group',
             'description' => 'A working group that is not a Clinical Domain Working Group',
             'can_be_parent' => true,
         ],
@@ -13,6 +14,7 @@ return [
             'id' => 2,
             'name' => 'cdwg',
             'fullname' => 'Clinical Domain Working Group',
+            'display_name' => 'Clinical Domain Working Group',
             'description' => 'A Clinical Domain Working Group that oversees Expert Panels.',
             'can_be_parent' => true,
         ],
@@ -20,16 +22,26 @@ return [
             'id' => 3,
             'name' => 'gcep',
             'fullname' => 'Gene Curation Expert Panel',
+            'display_name' => 'GCEP',
             'description' => 'A Gene curation expert panel',
             'can_be_parent' => false,
         ],
         'vcep' => [
             'id' => 4,
             'name' => 'vcep',
+            'display_name' => 'VCEP',
             'fullname' => 'Variant Curation Expert Panel',
             'description' => 'A Variant curation expert panel',
             'can_be_parent' => false,
-        ]
+        ],
+        'scvcep' => [
+            'id' => 5,
+            'name' => 'scvcep',
+            'fullname' => 'Somatic Cancer Variant Curation Expert Panel',
+            'display_name' => 'SCVCEP',
+            'description' => 'A Somatic cancer variant curation expert panel',
+            'can_be_parent' => false,
+        ],
     ],
     'statuses' => [
         'applying' => [

--- a/app/Modules/Group/groups.php
+++ b/app/Modules/Group/groups.php
@@ -109,6 +109,12 @@ return [
             'display_name' => 'Biocurator trainer',
             'description' => 'Biocurator trainer designation.  No default permissions.',
         ],
+        'civic-editor' => [
+            'id' => 106,
+            'name' => 'civic-editor',
+            'display_name' => 'CIVic Editor',
+            'description' => 'Individuals approves the submission of edits to CIViC. Indicates a higher level of training.  No default permissions.',
+        ],
     ],
     'permissions' => [
         'info-edit' => [

--- a/database/factories/ExpertPanelFactory.php
+++ b/database/factories/ExpertPanelFactory.php
@@ -28,15 +28,14 @@ class ExpertPanelFactory extends Factory
      */
     public function definition()
     {
-        $groupTypeId = $this->faker->randomElement([config('groups.types.gcep.id'), config('groups.types.vcep.id')]);
         return [
             'uuid' => Uuid::uuid4()->toString(),
             'group_id' => Group::factory()
                             ->create([
                                 'name' => 'group '.uniqid(),
-                                'group_type_id' => $groupTypeId
+                                'group_type_id' => config('groups.types.gcep.id')
                             ])->id,
-            'expert_panel_type_id' => $groupTypeId - 2,
+            'expert_panel_type_id' => config('groups.types.gcep.id') - 2,
             'date_initiated' => Carbon::now(),
             'current_step' => 1,
         ];

--- a/database/migrations/2021_08_06_184103_create_group_types_table.php
+++ b/database/migrations/2021_08_06_184103_create_group_types_table.php
@@ -26,8 +26,6 @@ class CreateGroupTypesTable extends Migration
         });
 
         Schema::enableForeignKeyConstraints();
-
-        (new GroupTypeSeeder)->run();
     }
 
     /**

--- a/database/migrations/2024_12_26_152704_add_display_name_to_group_types.php
+++ b/database/migrations/2024_12_26_152704_add_display_name_to_group_types.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->string('display_name')->after('fullname')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->dropColumn('display_name');
+        });
+    }
+};

--- a/resources/app/src/components/groups/GroupForm.vue
+++ b/resources/app/src/components/groups/GroupForm.vue
@@ -108,12 +108,7 @@ export default {
     ],
     data() {
         return {
-            groupTypes: [
-                {id: 1, fullname: 'Working Group'},
-                {id: 2, fullname: 'Clinical Domain Working Group'},
-                {id: 3, fullname: 'GCEP'},
-                {id: 4, fullname: 'VCEP'},
-            ],
+            groupTypes: configs.groups.types,
             groupStatuses: configs.groups.statuses,
             newGroup: new Group(),
             parents: []
@@ -140,7 +135,7 @@ export default {
             return Object.values(this.groupStatuses).map(status => ({value: status.id, label: this.titleCase(status.name)}))
         },
         typeOptions () {
-            return this.groupTypes.map(type => ({value: type.id, label: type.fullname}));
+            return Object.values(this.groupTypes).map(type => ({value: type.id, label: type.display_name}));
         },
         canSetType() {
             return this.hasPermission('groups-manage') && !this.group.id

--- a/resources/app/src/configs.json
+++ b/resources/app/src/configs.json
@@ -96,6 +96,7 @@
                 "id": 1,
                 "name": "wg",
                 "fullname": "Working Group",
+                "display_name": "Working Group",
                 "description": "A working group that is not a Clinical Domain Working Group",
                 "can_be_parent": true
             },
@@ -103,6 +104,7 @@
                 "id": 2,
                 "name": "cdwg",
                 "fullname": "Clinical Domain Working Group",
+                "display_name": "Clinical Domain Working Group",
                 "description": "A Clinical Domain Working Group that oversees Expert Panels.",
                 "can_be_parent": true
             },
@@ -110,14 +112,24 @@
                 "id": 3,
                 "name": "gcep",
                 "fullname": "Gene Curation Expert Panel",
+                "display_name": "GCEP",
                 "description": "A Gene curation expert panel",
                 "can_be_parent": false
             },
             "vcep": {
                 "id": 4,
                 "name": "vcep",
+                "display_name": "VCEP",
                 "fullname": "Variant Curation Expert Panel",
                 "description": "A Variant curation expert panel",
+                "can_be_parent": false
+            },
+            "scvcep": {
+                "id": 5,
+                "name": "scvcep",
+                "fullname": "Somatic Cancer Variant Curation Expert Panel",
+                "display_name": "SCVCEP",
+                "description": "A Somatic cancer variant curation expert panel",
                 "can_be_parent": false
             }
         },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,17 +17,20 @@ use Database\Seeders\EpTypesTableSeeder;
 use Illuminate\Foundation\Testing\WithFaker;
 use App\Modules\ExpertPanel\Actions\ContactAdd;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use WithFaker;
+    use RefreshDatabase;
     // Helper methods
 
     public function setup():void
     {
         parent::setup();
+        $this->seed(GroupTypeSeeder::class);
         TestResponse::macro('assertValidationErrors', function($validationErrrors) {
             $this->assertStatus(422)
                 ->assertInvalid($validationErrrors);


### PR DESCRIPTION
This PR adds the SCVCEP group type and foundational support. 

* Adds `display_name` to `group_types` table so we can use it in the UI.
* Adds scvcep type to `groups` config which is used to seed group types.
* Adds SCVCEP related accessors and scopes to Group and ExperPanel Models.
* Updates backend to assume SCVCEPs behave exactly like VCEPs.

SCVCEP specific functionality to follow.
