### PR TITLE
Add facets to group types

### DIFF
--- a/app/Modules/Group/Models/GroupType.php
+++ b/app/Modules/Group/Models/GroupType.php
@@ -24,7 +24,10 @@ class GroupType extends Model
     protected $fillable = [
         'name',
         'fullname',
-        'can_be_parent'
+        'can_be_parent',
+        'is_expert_panel',
+        'curates_variants',
+        'is_somatic_cancer',
     ];
 
     /**
@@ -35,6 +38,9 @@ class GroupType extends Model
     protected $casts = [
         'id' => 'integer',
         'can_be_parent' => 'boolean',
+        'is_expert_panel' => 'boolean',
+        'curates_variants' => 'boolean',
+        'is_somatic_cancer' => 'boolean',
     ];
 
     protected $hidden = ['created_at', 'updated_at'];

--- a/app/Modules/Group/groups.php
+++ b/app/Modules/Group/groups.php
@@ -8,6 +8,9 @@ return [
             'fullname' => 'Working Group',
             'description' => 'A working group that is not a Clinical Domain Working Group',
             'can_be_parent' => true,
+            'is_expert_panel' => false,
+            'curates_variants' => false,
+            'is_somatic_cancer' => false,
         ],
         'cdwg' => [
             'id' => 2,
@@ -15,6 +18,9 @@ return [
             'fullname' => 'Clinical Domain Working Group',
             'description' => 'A Clinical Domain Working Group that oversees Expert Panels.',
             'can_be_parent' => true,
+            'is_expert_panel' => false,
+            'curates_variants' => false,
+            'is_somatic_cancer' => false,
         ],
         'gcep' => [
             'id' => 3,
@@ -22,6 +28,9 @@ return [
             'fullname' => 'Gene Curation Expert Panel',
             'description' => 'A Gene curation expert panel',
             'can_be_parent' => false,
+            'is_expert_panel' => true,
+            'curates_variants' => false,
+            'is_somatic_cancer' => false,
         ],
         'vcep' => [
             'id' => 4,
@@ -29,6 +38,9 @@ return [
             'fullname' => 'Variant Curation Expert Panel',
             'description' => 'A Variant curation expert panel',
             'can_be_parent' => false,
+            'is_expert_panel' => true,
+            'curates_variants' => true,
+            'is_somatic_cancer' => false,
         ]
     ],
     'statuses' => [

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -33,7 +33,7 @@ class GroupFactory extends Factory
         return [
             'uuid' => $this->faker->uuid(),
             'name' => $this->faker->name(),
-            'group_type_id' => 1,
+            'group_type_id' => config('groups.types.wg.id'),
             'group_status_id' => $this->getRandomConfigValue('groups.statuses')['id'],
             'coi_code' => $code
         ];

--- a/database/factories/GroupTypeFactory.php
+++ b/database/factories/GroupTypeFactory.php
@@ -22,8 +22,11 @@ class GroupTypeFactory extends Factory
      */
     public function definition()
     {
+        $name = $this->faker->name;
         return [
-            'name' => $this->faker->name,
+            'name' => $name,
+            'fullName' => $name,
+            'description' => 'this is a test',
         ];
     }
 }

--- a/database/migrations/2021_08_06_184103_create_group_types_table.php
+++ b/database/migrations/2021_08_06_184103_create_group_types_table.php
@@ -26,8 +26,6 @@ class CreateGroupTypesTable extends Migration
         });
 
         Schema::enableForeignKeyConstraints();
-
-        (new GroupTypeSeeder)->run();
     }
 
     /**

--- a/database/migrations/2025_01_05_134906_add-facets-to-group-types.php
+++ b/database/migrations/2025_01_05_134906_add-facets-to-group-types.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('group_types', function ($table) {
+            $table->tinyInteger('is_expert_panel')->default(false);
+            $table->tinyInteger('curates_variants')->default(false);
+            $table->tinyInteger('is_somatic_cancer')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('group_types', function ($table) {
+            $table->dropColumn('is_expert_panel');
+            $table->dropColumn('creates_variants');
+            $table->dropColumn('is_somatic_cancer');
+        });
+    }
+};

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,12 +17,14 @@ use Database\Seeders\EpTypesTableSeeder;
 use Illuminate\Foundation\Testing\WithFaker;
 use App\Modules\ExpertPanel\Actions\ContactAdd;
 use App\Modules\ExpertPanel\Models\ExpertPanel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use WithFaker;
+    use RefreshDatabase;
     // Helper methods
 
     public function setup():void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,7 @@ abstract class TestCase extends BaseTestCase
     public function setup():void
     {
         parent::setup();
+        $this->seed(GroupTypeSeeder::class);
         TestResponse::macro('assertValidationErrors', function($validationErrrors) {
             $this->assertStatus(422)
                 ->assertInvalid($validationErrrors);

--- a/tests/Unit/Modules/Service/Group/Models/GroupTest.php
+++ b/tests/Unit/Modules/Service/Group/Models/GroupTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use App\Modules\Group\Models\Group;
+use App\Modules\Group\Models\GroupType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group group-model
+ */
+class GroupTest extends TestCase
+{
+  use RefreshDatabase;
+
+  private Group $wg;
+  private Group $vcep;
+  private Group $gcep;
+  private Group $scvcep;
+
+  public function setup(): void
+  {
+      parent::setup();
+      $this->wg = Group::factory()->wg()->make();
+      $this->vcep = Group::factory()->vcep()->make();
+      $this->gcep = Group::factory()->gcep()->make();
+      
+      $scvcepType = GroupType::factory()->create(['is_expert_panel' => true, 'curates_variants' => true, 'is_somatic_cancer' => true]);
+      $this->scvcep = Group::factory()->make(['group_type_id' => $scvcepType]);
+      $this->assertTrue(true);
+  }
+  
+
+  /**
+   * @test
+   */
+  public function it_knows_if_it_is_an_expert_panel():void
+  {
+      $nonEpGroupType = GroupType::where('is_expert_panel', 0)->firstOrFail();
+      $this->assertFalse(Group::factory()->make(['group_type_id' => $nonEpGroupType->id])->isEp);
+
+      $epGroupType = GroupType::where('is_expert_panel', 1)->firstOrFail();       
+      $this->assertTrue(Group::factory()->make(['group_type_id' => $epGroupType->id])->isEp);
+  }
+
+  /**
+   * @test
+   */
+  public function it_knows_if_it_is_a_vcep():void
+  {
+    $this->assertTrue($this->vcep->isVcep);
+
+    $this->assertFalse($this->wg->isVcep);
+    $this->assertFalse($this->gcep->isVcep);
+    $this->assertFalse($this->scvcep->isVcep);
+    
+  }
+  
+  /**
+   * @test
+   */
+  public function it_knows_if_it_curates_variants():void
+  {
+    $this->assertTrue($this->scvcep->curatesVariants);
+    $this->assertTrue($this->vcep->curatesVariants);
+
+    $this->assertFalse($this->wg->curatesVariants);
+    $this->assertFalse($this->gcep->curatesVariants);  
+  }
+
+  /**
+   * @test
+   */
+  public function it_knows_if_it_is_a_somatic_cancer():void
+  {
+    $this->assertTrue($this->scvcep->isSomaticCancer);
+    
+    $this->assertFalse($this->vcep->isSomaticCancer);
+    $this->assertFalse($this->wg->isSomaticCancer);
+    $this->assertFalse($this->gcep->isSomaticCancer);  
+  }
+  
+  
+  
+}


### PR DESCRIPTION
With the addition of SCVCEPs I believe we should begin making decisions on behavior and display based on attributes of the groups as opposed to their type names.  To facilitate this let's add attributes to the `GroupType` that describe the group in a little more detail.

This PR adds `is_expert_panel`, `curates_variants`, and `is_somatic_cancer` attributes to the `GroupType` model.  
The `Group` model now uses its type's attributes in its accessors.

Once this PR is merged we can add these facets to the group API responses in a following PR.