### PR TITLE
Finish replacing client-side group-type eval w/ server-based attributes

### DIFF
--- a/resources/app/src/components/expert_panels/AttestationNhgri.vue
+++ b/resources/app/src/components/expert_panels/AttestationNhgri.vue
@@ -1,11 +1,16 @@
 <template>
     <div>
-        <p v-if="group.isVcep()">
-            Curated variants and genes are expected to be approved and posted for the community as soon as possible as described in Section 2.4 of the <vcep-protocol-link />. 
-            Note that upon approval, a VCEP must finalize their set of variants for upload to the ClinGen Evidence Repository within 30 days.
+        <p v-if="group.is_vcep">
+            Curated variants and genes are expected to be approved and posted
+            for the community as soon as possible as described in Section 2.4 of
+            the <vcep-protocol-link />. Note that upon approval, a VCEP must
+            finalize their set of variants for upload to the ClinGen Evidence
+            Repository within 30 days.
         </p>
         <p v-if="group.is_gcep">
-            Curated genes and variants are expected to be approved and posted for the community as soon as possible and should not wait for the publication of a manuscript.
+            Curated genes and variants are expected to be approved and posted
+            for the community as soon as possible and should not wait for the
+            publication of a manuscript.
         </p>
 
         <p class="my-4">
@@ -22,10 +27,17 @@
         <p v-if="group.is_vcep_or_scvcep">
             Please review the
             <publication-policy-link />
-            and refer to guidance on submissions to a preprint server (e.g. bioRxiv or medRxiv).
+            and refer to guidance on submissions to a preprint server (e.g.
+            bioRxiv or medRxiv).
         </p>
         <p v-if="group.is_gcep">
-            <em>It is expected that, whenever possible, Expert Panel manuscripts will be pre-published (e.g. medRXiv) . If the authors do not anticipate submitting their manuscript to a prepublication resource they must provide a written justification.</em>
+            <em
+                >It is expected that, whenever possible, Expert Panel
+                manuscripts will be pre-published (e.g. medRXiv) . If the
+                authors do not anticipate submitting their manuscript to a
+                prepublication resource they must provide a written
+                justification.</em
+            >
         </p>
     </div>
 </template>

--- a/resources/app/src/components/groups/MemberForm.vue
+++ b/resources/app/src/components/groups/MemberForm.vue
@@ -76,7 +76,9 @@
                     </div>
                     <transition name="fade-down">
                         <div
-                            v-if="newMember.hasRole('biocurator') && group.isVcep()"
+                            v-if="
+                                newMember.hasRole('biocurator') && group.is_vcep
+                            "
                             class="border-t mt-2 pt-2 pl-2"
                         >
                             <h4>Training</h4>

--- a/resources/app/src/components/log_entries/ActivityLogEntryForm.vue
+++ b/resources/app/src/components/log_entries/ActivityLogEntryForm.vue
@@ -6,7 +6,11 @@
             type="date" 
             ref="logdate"
         ></input-row>
-        <StepInput :errors="errors.step" v-if="group.isVcep()" v-model="newEntry.step"/>
+        <StepInput
+            :errors="errors.step"
+            v-if="group.is_vcep"
+            v-model="newEntry.step"
+        />
         <input-row label="Entry" :errors="errors.entry">
             <RichTextEditor v-model="newEntry.entry" />
         </input-row>

--- a/resources/app/src/domain/group.js
+++ b/resources/app/src/domain/group.js
@@ -191,14 +191,6 @@ class Group extends Entity {
         return this.attributes.group_type_id === configs.groups.types.cdwg.id;
     }
 
-    isVcep() {
-        return this.is_vcep;
-    }
-
-    isGcep() {
-        return this.is_gcep;
-    }
-
     documentsOfType(docTypeId) {
         return this.documents.filter(d =>  d.document_type_id == docTypeId)
     }


### PR DESCRIPTION
We missed a few along the way.  This completely removes old references to client-side eval of group type.