### PR TITLE
Api responds with group facets

### DIFF
--- a/app/Modules/Group/Http/Resources/GroupResource.php
+++ b/app/Modules/Group/Http/Resources/GroupResource.php
@@ -29,7 +29,6 @@ class GroupResource extends JsonResource
         $data['is_gcep'] = $this->isGcep;
         $data['is_scvcep'] = $this->isScvcep;
         $data['is_vcep_or_scvcep'] = $this->isVcepOrScvcep;
-        // $data['parent'] = $this->whenLoaded('parent', GroupResource::collection($this->parent));
 
 
         unset($data['members'], $data['created_at'], $data['deleted_at']);

--- a/app/Modules/Group/Http/Resources/GroupTypeResource.php
+++ b/app/Modules/Group/Http/Resources/GroupTypeResource.php
@@ -20,6 +20,9 @@ class GroupTypeResource extends JsonResource
             'name' => $data['name'],
             'fullname' => $data['fullname'],
             'display_name' => $data['display_name'],
+            'can_be_parent' => $data['can_be_parent'],
+            'curation_product' => $data['curation_product'],
+            'is_somatic_cancer' => $data['is_somatic_cancer'],
         ];
     }
 }

--- a/app/Modules/Group/Models/Group.php
+++ b/app/Modules/Group/Models/Group.php
@@ -239,17 +239,17 @@ class Group extends Model implements HasNotes, HasMembers, RecordsEvents, HasDoc
 
     public function getIsVcepAttribute(): bool
     {
-        return $this->group_type_id == config('groups.types.vcep.id');
+        return $this->type->curation_product === CurationProduct::Variant && $this->type->is_somatic_cancer === false;
     }
 
     public function getIsGcepAttribute(): bool
     {
-        return $this->group_type_id == config('groups.types.gcep.id');
+        return $this->type->curation_product === CurationProduct::Gene;
     }
 
     public function getIsScvcepAttribute(): bool
     {
-        return $this->group_type_id == config('groups.types.scvcep.id');
+        return $this->isVcep && $this->type->is_somatic_cancer;
     }
 
     public function getIsVcepOrScvcepAttribute(): bool

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -46,7 +46,7 @@ class GroupFactory extends Factory
                 'uuid' => $this->faker->uuid,
                 'name' => uniqid().' CDWG',
                 'group_type_id' => config('groups.types.vcep.id'),
-                'group_status_id' => config('groups.statuses.applying.id')
+                'group_status_id' => config('groups.statuses.applying.id'),
             ];
         });
     }
@@ -58,7 +58,7 @@ class GroupFactory extends Factory
                 'uuid' => $this->faker->uuid,
                 'name' => uniqid().' CDWG',
                 'group_type_id' => config('groups.types.gcep.id'),
-                'group_status_id' => config('groups.statuses.applying.id')
+                'group_status_id' => config('groups.statuses.applying.id'),
             ];
         });
     }
@@ -70,7 +70,7 @@ class GroupFactory extends Factory
                 'uuid' => $this->faker->uuid,
                 'name' => uniqid().' scvcep',
                 'group_type_id' => config('groups.types.scvcep.id'),
-                'group_status_id' => config('groups.statuses.applying.id')
+                'group_status_id' => config('groups.statuses.applying.id'),
             ];
         });
     }


### PR DESCRIPTION
I'd like to start using the new facets instead `isGcep`, `isVcep`, etc. on the frontend, so I'm added them to the GroupType resource.

This PR also replaces GroupType ID checks to determine the groups type with checks against the facets.